### PR TITLE
EXP-12497: bump @az/app-switcher to 2.32.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "yarn": "^1.21.1"
   },
   "dependencies": {
-    "@az/app-switcher": "2.32.1",
+    "@az/app-switcher": "2.32.3",
     "@az/common-configs": "9.30.0",
     "@az/internal-protos": "1.7.54-dev-FY27CRT-R4-v11",
     "@az/utility": "^2.8.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@az/app-switcher@2.32.1":
-  version "2.32.1"
-  resolved "https://nexus.mgmt.dev.appzen.com/repository/npm-appzen/@az/app-switcher/-/app-switcher-2.32.1.tgz#7326ffd437eb5473f028abb15c29361690e4104d"
-  integrity sha512-48ZiVPH8E1SPzEShysyVazwqPsOl+PVCPNYwfUz4+zNen0m1MWqC8zMrd6V/9Nd/9mRUJMJWlKgtsNGKSoicDA==
+"@az/app-switcher@2.32.3":
+  version "2.32.3"
+  resolved "https://nexus.mgmt.dev.appzen.com/repository/npm-appzen/@az/app-switcher/-/app-switcher-2.32.3.tgz#2a6cf0c61690d75e8786408e765941b859418e56"
+  integrity sha512-SY5gPF6zJn6Z3n7jmQK49XKtKmfjoaM7DHON1XDnhC36wmOkDqBFePlSxlQvUeM3iJsuKm+ANE6l32aRvYok+A==
   dependencies:
     "@az/common-configs" "9.33.0"
     "@az/utility" "2.8.8"


### PR DESCRIPTION
Picks up the sidenav predicate fix for FunctionalAdminReadOnly and MMFunctionalAdminReadOnly roles. Companion to az-ui PR #2835.

## Summary

Summarize your PR. If it involves visual changes include a screenshot or gif.

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
