### PR TITLE
AAP-8295: fix mastermind root redirect loop on multi-slash paths

### DIFF
--- a/src/legacy/server/http/index.js
+++ b/src/legacy/server/http/index.js
@@ -30,6 +30,16 @@ export default async function (kbnServer, server) {
 
   await registerHapiPlugins(server);
 
+  // For multi-slash root paths (e.g. `//`) we want to break redirect loops
+  // caused by upstream proxies that don't merge slashes — sending the user
+  // to the configured default landing page instead of looping back to `/`.
+  // Read the YAML-configured override at setup time so the destination can
+  // be changed by editing kibana.yml (deploy values.yaml) without a code
+  // change. Falls back to Kibana's built-in defaultRoute default.
+  const uiSettings = kbnServer.config.has('uiSettings') ? kbnServer.config.get('uiSettings') : {};
+  const multiSlashRedirectTarget =
+    (uiSettings && uiSettings.overrides && uiSettings.overrides.defaultRoute) || '/app/home';
+
   server.route({
     method: 'GET',
     path: '/{p*}',
@@ -37,6 +47,18 @@ export default async function (kbnServer, server) {
       const path = req.path;
       if (path === '/' || path.charAt(path.length - 1) !== '/') {
         throw Boom.notFound();
+      }
+
+      // Defensive: some upstream proxies deliver `GET /` to Kibana as `GET //`
+      // (observed on AppZen PROD ingress; RCST normalizes). Without this
+      // branch, falling through below emits `301 -> /`, which the same proxy
+      // re-doubles to `//` and creates an infinite redirect loop. For all-
+      // slash root paths (`//`, `///`, ...) redirect to the configured default
+      // landing page — that path is not mutated by the ingress, so the cycle
+      // breaks on the next hop. Safe to remove once the ingress is configured
+      // to merge slashes.
+      if (/^\/+$/.test(path)) {
+        return h.redirect(multiSlashRedirectTarget).permanent(true);
       }
 
       const pathPrefix = req.getBasePath() ? `${req.getBasePath()}/` : '';


### PR DESCRIPTION
Patch legacy /{p*} handler to detect all-slash root paths ('//', '///', ...) and redirect to the configured uiSettings.overrides.defaultRoute (falling back to /app/home) instead of stripping a trailing slash and emitting 301 -> /, which loops behind ingresses that don't merge slashes (observed on PROD; RCST normalizes).

PR-2008 added the YAML override but couldn't fix the loop because core_app's '/' handler is never reached when hapi routes '//' to the legacy catch-all first. This patch reuses the same override key so future retargeting stays a values.yaml edit.
