### PR TITLE
AAP-8534 fix(capabilities): sanitize applications to prevent navLink key injec…

### DIFF
--- a/src/core/server/capabilities/resolve_capabilities.test.ts
+++ b/src/core/server/capabilities/resolve_capabilities.test.ts
@@ -135,6 +135,27 @@ describe('resolveCapabilities', () => {
     });
   });
 
+  it('adds the requested applications to the navLinks', async () => {
+    const result = await resolveCapabilities(defaultCaps, [], request, [
+      'kibana:dashboard',
+      'my_app',
+    ]);
+    expect(result.navLinks).toEqual({
+      'kibana:dashboard': true,
+      my_app: true,
+    });
+  });
+
+  it('filters out applications containing invalid characters', async () => {
+    const result = await resolveCapabilities(defaultCaps, [], request, [
+      'valid_app',
+      'invoice<script>alert(1)</script>x',
+    ]);
+    expect(result.navLinks).toEqual({
+      valid_app: true,
+    });
+  });
+
   it('ignores any capability type mutation from the switcher', async () => {
     const caps = {
       ...defaultCaps,

--- a/src/core/server/capabilities/resolve_capabilities.ts
+++ b/src/core/server/capabilities/resolve_capabilities.ts
@@ -26,6 +26,11 @@ export type CapabilitiesResolver = (
   applications: string[]
 ) => Promise<Capabilities>;
 
+const VALID_APPLICATION_ID = /^[a-zA-Z0-9:._-]+$/;
+
+const filterValidApplications = (applications: string[]): string[] =>
+  applications.filter((app) => VALID_APPLICATION_ID.test(app));
+
 export const getCapabilitiesResolver = (
   capabilities: () => Capabilities,
   switchers: () => CapabilitiesSwitcher[]
@@ -44,7 +49,7 @@ export const resolveCapabilities = async (
 ): Promise<Capabilities> => {
   const mergedCaps = cloneDeep({
     ...capabilities,
-    navLinks: applications.reduce(
+    navLinks: filterValidApplications(applications).reduce(
       (acc, app) => ({
         ...acc,
         [app]: true,


### PR DESCRIPTION
### fix(capabilities): sanitize applications to prevent navLink key injection (AAP-8534)

### Summary

Fixes AAP-8534 (https://appzen.atlassian.net/browse/AAP-8534) — API Capabilities JSON Manipulation on /api/core/capabilities (NCC-WAPT-QHJ, Low severity).

POST /api/core/capabilities reflects the client-supplied applications array as keys in the response navLinks object. Previously any string was accepted, so a payload like `invoice<script>alert(1)</script>x` would be echoed back as a JSON key — which could be chained into XSS or unexpected serialization.

  Changes

- Added an allowlist regex (/^[a-zA-Z0-9:._-]+$/) and filter applications against it in resolveCapabilities before they're merged into navLinks. Malicious-character payloads are dropped; legitimate app IDs (e.g. kibana:dashboard, my_app) are unaffected.
- The filter lives in the shared resolver, so it covers every caller, not just the route handler.
- Added unit tests: one asserting valid IDs are reflected as navLinks, one asserting the XSS payload is filtered out.

Testing

- node scripts/jest.js src/core/server/capabilities/resolve_capabilities.test.ts — 8/8 passing (run under Node 12 per repo engine pin).